### PR TITLE
Fix for Get Transaction Status

### DIFF
--- a/src/Services/Payments.php
+++ b/src/Services/Payments.php
@@ -80,7 +80,7 @@ class Payments
 
         $payload = [
             'api' => 170,
-            'code' => 103,
+            'code' => 105,
             'data' => $data,
         ];
         $response = $this->httpClient->post('', [


### PR DESCRIPTION
Hello Alpha,

I have switched the `code` from 103 to 105 in the `find($id)` method as indicated by the documentation for fetching specific order status. The 103 returns statuses for all orders, not a specified order.

Long live open source!
George Raphael Kitula